### PR TITLE
docs: leadership assessment questions redesign

### DIFF
--- a/apps/web/src/pages/MemberDetailPage.tsx
+++ b/apps/web/src/pages/MemberDetailPage.tsx
@@ -88,11 +88,14 @@ export default function MemberDetailPage() {
             {user.name.charAt(0).toUpperCase()}
           </div>
           <div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
               <h1 className="text-xl font-bold text-gray-900">{user.name}</h1>
               {user.role === 'manager' && (
                 <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-orange-100 text-orange-700">Manager</span>
               )}
+              {memberTeams.map(t => (
+                <span key={t.id} className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-blue-50 text-blue-600">{t.name}</span>
+              ))}
             </div>
             <p className="text-xs text-gray-400">{user.id}</p>
           </div>

--- a/docs/leadership-questions-redesign.md
+++ b/docs/leadership-questions-redesign.md
@@ -1,0 +1,106 @@
+# Leadership Assessment Questions — Redesign Proposal
+
+## Current Questions — Critique
+
+The existing 12 questions are **self-report attitude statements** ("I am good at...", "I believe...", "I like to..."). From a user research / ethnographic perspective, they suffer from several well-known biases:
+
+| Problem | Impact |
+|---------|--------|
+| **Social desirability bias** | People rate themselves higher on "nice" behaviors (coaching, catalyzing) and lower on "harsh" ones (directing, demanding) |
+| **Abstraction bias** | Statements like "I prioritize long-term growth over short-term results" are aspirational — they measure *identity*, not *behavior* |
+| **Acquiescence bias** | All items are positively framed ("I am good at...") — respondents tend to agree |
+| **No situational anchor** | Without a concrete scenario, people default to their idealized self |
+| **Transparent intent** | It's easy to guess what each question measures, enabling gaming |
+
+---
+
+## Redesigned Questions — Behavioral & Situational
+
+The key shift: **from "who do you think you are" → "what do you actually do when X happens"**. Each question describes a concrete situation and asks how frequently the respondent behaves that way. Same 1–10 scale (Never → Always), same pair structure.
+
+### Pair 1: Catalyzing (Q1 + Q11)
+
+**Q1** — *When your team is stuck in a recurring pattern that no longer works, you step back and help them see the system-level dynamics rather than jumping in with a fix.*
+
+**Q11** — *When a team is performing well, you actively remove yourself from decision-making so they can self-organize, even if you'd do it differently.*
+
+**Why better**: The old Q1 ("I am good at encouraging teams to challenge assumptions") is self-congratulatory. The new version forces a choice: do you *actually* step back, or do you intervene? Q11 adds the tension of letting go when things are going well — the real test of catalyzing.
+
+---
+
+### Pair 2: Envisioning (Q2 + Q9)
+
+**Q2** — *When starting a new initiative, you spend significant time painting a picture of what success looks like before discussing how to get there.*
+
+**Q9** — *When assigning work, you describe the destination and the "why" rather than breaking it down into specific tasks and deadlines.*
+
+**Why better**: The old Q2 ("getting people on board, motivating them towards compelling goals") confounds motivation with vision. The new version isolates the *envisioning* behavior: do you invest in the future picture, or jump to execution? Q9 creates a direct tension between goal-framing vs. task-framing.
+
+---
+
+### Pair 3: Demanding (Q3 + Q12)
+
+**Q3** — *When quality drops below your standards, you personally demonstrate the correct approach and expect the team to match that level immediately.*
+
+**Q12** — *When you delegate a responsibility, you maintain a clear "pull-back" threshold — if results slip, you retake control without hesitation.*
+
+**Why better**: The old Q3 ("modeling desired behaviors and expecting others to follow") is too generic. The new version anchors it in a **quality crisis** — when do you actually step in and model? Q12 makes the demanding/control dynamic explicit and situational rather than aspirational.
+
+---
+
+### Pair 4: Coaching (Q4 + Q10)
+
+**Q4** — *When a team member brings you a problem, your default response is to ask questions that help them find their own answer, even when you already know the solution.*
+
+**Q10** — *When under pressure to deliver, you still invest time in developing people's capabilities rather than just getting the task done yourself.*
+
+**Why better**: The old Q4 ("my solution is never as effective as theirs") is a belief statement anyone can agree with. The new version tests the *behavioral cost*: do you hold back your answer? Q10 adds time pressure — the real test of coaching commitment.
+
+---
+
+### Pair 5: Conducting (Q5 + Q7)
+
+**Q5** — *When your team faces a decision, you actively facilitate discussion to ensure every voice is heard before the group commits to a direction.*
+
+**Q7** — *When someone on your team is blocked, you focus on connecting them with the right people and removing obstacles rather than solving the problem yourself.*
+
+**Why better**: The old Q5 mixed collaboration with target-monitoring. The new version isolates the *democratic facilitation* behavior. Q7 shifts from "making sure they have access" (passive) to active obstacle-removal — a more observable behavior.
+
+---
+
+### Pair 6: Directing (Q6 + Q8)
+
+**Q6** — *When onboarding someone new or launching a project, you provide detailed expectations, clear boundaries, and specific deliverables upfront.*
+
+**Q8** — *When assembling a team for a project, you carefully match individuals to roles based on their specific strengths rather than letting people self-select.*
+
+**Why better**: The old Q6 ("ensuring high quality by being clear about expectations") is universally agreeable. The new version anchors it in a specific moment (onboarding/launch) where directing behavior is observable. Q8 tests the control-vs-autonomy tension directly.
+
+---
+
+## Design Principles Applied
+
+1. **Situational anchoring** — every question starts with "When [specific situation]..." to ground responses in real behavior
+2. **Behavioral language** — describes actions ("you step back", "you ask questions") not traits ("I am good at")
+3. **Built-in tension** — each question implies a trade-off (e.g., coaching vs. speed, directing vs. self-selection) so respondents can't just agree with everything
+4. **Reduced transparency** — harder to guess which archetype a question maps to
+5. **Paired consistency** — each pair tests the same behavior in two different contexts (proactive vs. reactive, low-pressure vs. high-pressure)
+
+---
+
+## Quick Reference — New vs Old
+
+| # | Behavior | Old (attitude) | New (situational) |
+|---|----------|----------------|-------------------|
+| Q1 | Catalyzing | "I am good at encouraging teams to challenge assumptions..." | "When your team is stuck in a recurring pattern..." |
+| Q2 | Envisioning | "I am good at getting people on board, motivating them..." | "When starting a new initiative, you spend time painting a picture..." |
+| Q3 | Demanding | "I believe in modeling desired behaviors and expecting others to follow" | "When quality drops below your standards, you personally demonstrate..." |
+| Q4 | Coaching | "I believe my solution is never as effective as theirs" | "When a team member brings you a problem, you ask questions..." |
+| Q5 | Conducting | "I encourage people to work together while meeting targets" | "When your team faces a decision, you facilitate discussion..." |
+| Q6 | Directing | "I like to ensure high quality by being clear about expectations" | "When onboarding someone new, you provide detailed expectations..." |
+| Q7 | Conducting | "I like to make sure individuals can access people and resources" | "When someone is blocked, you connect them with the right people..." |
+| Q8 | Directing | "I like to make sure the right work is allocated to the right people" | "When assembling a team, you match individuals to roles by strengths..." |
+| Q9 | Envisioning | "I like to share goals to reach for, rather than tasks" | "When assigning work, you describe the destination and the why..." |
+| Q10 | Coaching | "I prioritize long-term growth over short-term results" | "When under pressure to deliver, you still invest in developing people..." |
+| Q11 | Catalyzing | "I take a back seat and support my team to govern themselves" | "When a team is performing well, you remove yourself from decisions..." |
+| Q12 | Demanding | "I will delegate but reserve the right to resume control" | "When you delegate, you maintain a pull-back threshold..." |


### PR DESCRIPTION
## Summary
- Behavioral & situational questions to replace current self-report attitude statements
- Addresses social desirability bias, acquiescence bias, abstraction bias, and transparent intent
- Same 12 questions, same pair structure, same 1–10 scale — just better wording

## Contents
- Critique of current questions with bias analysis
- 12 redesigned questions anchored in concrete situations
- Design principles (situational anchoring, behavioral language, built-in tension)
- Old vs new comparison table

🤖 Generated with [Claude Code](https://claude.com/claude-code)